### PR TITLE
fix(converters): allow nullable return type in Convert method

### DIFF
--- a/SketchNow/Converters/DivisionMathConverter.cs
+++ b/SketchNow/Converters/DivisionMathConverter.cs
@@ -6,7 +6,7 @@ namespace SketchNow.Converters
 {
     public class DivisionMathConverter : IValueConverter
     {
-        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             if (value == null || parameter == null)
                 return null;


### PR DESCRIPTION
Updated the `Convert` method in the `DivisionMathConverter` class to return a nullable object type (`object?`) instead of a non-nullable object. This change allows the method to explicitly return `null` as a valid value.