### PR TITLE
feat(ink-canvas): add pressure factor control for stylus

### DIFF
--- a/SketchNow/Controls/CustomInkCanvas.cs
+++ b/SketchNow/Controls/CustomInkCanvas.cs
@@ -4,12 +4,29 @@ using SketchNow.Input.StylusPlugIns;
 
 namespace SketchNow.Controls;
 
-public class CustomInkCanvas : InkCanvas
+public sealed class CustomInkCanvas : InkCanvas
 {
-    private readonly CustomStylusPlugin _customStylusPlugin = new();
+    private readonly CustomStylusPlugin _customStylusPlugin = new() { PressureFactor = 0.1f };
 
     public CustomInkCanvas()
     {
+        StylusPlugIns.Add(_customStylusPlugin);
+    }
+
+    /// <summary>
+    /// Changes the pressure factor.
+    /// </summary>
+    /// <param name="pressureFactor">The pressure factor.</param>
+    /// <exception cref="ArgumentException">Pressure factor must be between 0 and 1</exception>
+    public void ChangePressureFactor(float pressureFactor)
+    {
+        if (pressureFactor < 0.0 || pressureFactor > 1.0)
+        {
+            throw new ArgumentException("Pressure factor must be between 0 and 1");
+        }
+
+        StylusPlugIns.Remove(_customStylusPlugin);
+        _customStylusPlugin.PressureFactor = pressureFactor;
         StylusPlugIns.Add(_customStylusPlugin);
     }
 }

--- a/SketchNow/Input/StylusPlugIns/CustomStylusPlugin.cs
+++ b/SketchNow/Input/StylusPlugIns/CustomStylusPlugin.cs
@@ -1,15 +1,39 @@
+using System.Windows.Input;
 using System.Windows.Input.StylusPlugIns;
 
 namespace SketchNow.Input.StylusPlugIns;
 
-public class CustomStylusPlugin : StylusPlugIn
+public sealed class CustomStylusPlugin : StylusPlugIn
 {
+
+    /// <summary>
+    /// Gets or sets a value between 0 and 1 that reflects the amount of pressure the stylus applies to the digitizer's surface when the <see cref="StylusPoint" /> is created.
+    /// </summary>
+    /// <value>
+    /// The pressure factor.
+    /// </value>
+    /// <returns>Value between 0 and 1 indicating the amount of pressure the stylus applies to the digitizer's surface as the <see cref="StylusPoint" /> is created.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">The <see cref="StylusPoint.PressureFactor" /> property is set to a value less than 0 or greater than 1.</exception>
+    public float PressureFactor
+    {
+        get
+        {
+            return field > 1.0 ? 1f : field < 0.0 ? 0.0f : field;
+        }
+        set
+        {
+            field = value >= 0.0 && value <= 1.0
+                ? value
+                : throw new ArgumentOutOfRangeException(nameof(PressureFactor),
+                    Properties.Resource.InvalidPressureValue);
+        }
+    }
     protected override void OnStylusDown(RawStylusInput rawStylusInput)
     {
         // Call the base class before modifying the data.
         base.OnStylusDown(rawStylusInput);
 
-        rawStylusInput.SetStylusPoints(rawStylusInput.GetStylusPoints());
+        Filter(rawStylusInput);
     }
 
     protected override void OnStylusMove(RawStylusInput rawStylusInput)
@@ -17,7 +41,7 @@ public class CustomStylusPlugin : StylusPlugIn
         // Call the base class before modifying the data.
         base.OnStylusMove(rawStylusInput);
 
-        rawStylusInput.SetStylusPoints(rawStylusInput.GetStylusPoints());
+        Filter(rawStylusInput);
     }
 
     protected override void OnStylusUp(RawStylusInput rawStylusInput)
@@ -25,6 +49,23 @@ public class CustomStylusPlugin : StylusPlugIn
         // Call the base class before modifying the data.
         base.OnStylusUp(rawStylusInput);
 
-        rawStylusInput.SetStylusPoints(rawStylusInput.GetStylusPoints());
+        Filter(rawStylusInput);
+    }
+
+    private void Filter(RawStylusInput rawStylusInput)
+    {
+        // Get the StylusPoints that have come in.
+        StylusPointCollection stylusPoints = rawStylusInput.GetStylusPoints();
+
+        // Modify the (X,Y) data
+        for (int i = 0; i < stylusPoints.Count; i++)
+        {
+            StylusPoint sp = stylusPoints[i];
+            sp.PressureFactor = PressureFactor;
+            stylusPoints[i] = sp;
+        }
+
+        // Copy the modified StylusPoints back to the RawStylusInput.
+        rawStylusInput.SetStylusPoints(stylusPoints);
     }
 }


### PR DESCRIPTION
Set default PressureFactor in CustomInkCanvas and add ChangePressureFactor method for dynamic adjustment. Introduce PressureFactor property in CustomStylusPlugin with validation, and refactor stylus input methods to use a new Filter method for pressure adjustments.