### PR TITLE
chore: update package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,18 +25,18 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageVersion>
     <PackageVersion Include="MaterialDesignThemes" Version="5.2.1" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.3" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="3.5.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.1" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="SingleInstanceCore" Version="2.2.2" />
-    <PackageVersion Include="System.Text.Json" Version="9.0.3" />
+    <PackageVersion Include="System.Text.Json" Version="9.0.4" />
     <PackageVersion Include="ValueConverters" Version="3.1.22" />
     <PackageVersion Include="Velopack" Version="0.0.1053" />
     <PackageVersion Include="WPF.JoshSmith.Controls.DragCanvas" Version="2.0.3" />


### PR DESCRIPTION
chore: update package versions

Updated the following package versions:
- `Microsoft.Extensions.DependencyInjection`, `Microsoft.Extensions.Hosting`, and `Microsoft.Extensions.Logging` from 9.0.3 to 9.0.4.
- `Serilog.Extensions.Logging` from 9.0.0 to 9.0.1.
- `System.Text.Json` from 9.0.3 to 9.0.4.

Other packages remain unchanged.